### PR TITLE
Fix list label for `week5_transfer_learning.ipynb` file

### DIFF
--- a/week5_transfer_learning.ipynb
+++ b/week5_transfer_learning.ipynb
@@ -37,7 +37,7 @@
         "\n",
         " You do not need to (re)train the entire model. The base convolutional network already contains features that are generically useful for classifying pictures. However, the final, classification part of the pretrained model is specific to the original classification task, and subsequently specific to the set of classes on which the model was trained.\n",
         "\n",
-        "1. Fine-Tuning: Unfreeze a few of the top layers of a frozen model base and jointly train both the newly-added classifier layers and the last layers of the base model. This allows us to \"fine-tune\" the higher-order feature representations in the base model in order to make them more relevant for the specific task.\n",
+        "2. Fine-Tuning: Unfreeze a few of the top layers of a frozen model base and jointly train both the newly-added classifier layers and the last layers of the base model. This allows us to \"fine-tune\" the higher-order feature representations in the base model in order to make them more relevant for the specific task.\n",
         "\n",
         "You will follow the general machine learning workflow.\n",
         "\n",


### PR DESCRIPTION
Week 5 transfer learning `.ipynb` file has the wrong list label.
See image below for error:

<img width="1170" height="557" alt="Screenshot 2025-10-16 at 1 15 41 pm" src="https://github.com/user-attachments/assets/b2d4dffb-9d1d-49a1-be61-b5d9279cb5ec" />

This PR fixes the order label.
